### PR TITLE
Plone 5: Register jqueryui resources not as bundle (does not work for…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ JQueryUI Changelog: http://jqueryui.com/changelog/
 
 Bug fixes:
 
+- Plone 5: Register jqueryui resources not as bundle (does not work for generated browser page based resources) but add it to the plone-legacy bundle.
+  [thet]
+
 - Simplify resource registration for Plone 5 the way done in
   https://github.com/collective/example.p4p5#cssjs-declaration-in-plone-5
   [rnix]

--- a/collective/js/jqueryui/profiles/default/registry.xml
+++ b/collective/js/jqueryui/profiles/default/registry.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0"?>
 <registry>
 
-  <records prefix="plone.bundles/jqueryui"
-           interface='Products.CMFPlone.interfaces.IBundleRegistry'>
-    <value key="enabled">True</value>
-    <value key="jscompilation">collective.js.jqueryui.custom.min.js</value>
-    <value key="csscompilation">collective.js.jqueryui.custom.min.css</value>
-    <value key="compile">False</value>
-    <value key="depends">plone</value>
+  <records remove="True" prefix="plone.bundles/jqueryui" interface='Products.CMFPlone.interfaces.IBundleRegistry'/>
+
+  <records prefix="plone.resources/jqueryui" interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+    <value key="js">collective.js.jqueryui.custom.min.js</value>
+    <value key="css">
+      <element>collective.js.jqueryui.custom.min.css</element>
+    </value>
+  </records>
+
+  <records purge="False" prefix="plone.bundles/plone-legacy" interface="Products.CMFPlone.interfaces.IBundleRegistry">
+    <value key="last_compilation"></value>
+    <value key="resources" purge="False">
+      <element>jqueryui</element>
+    </value>
   </records>
 
 </registry>


### PR DESCRIPTION
… generated browser page based resources) but add it to the plone-legacy bundle.