### PR TITLE
5.2 is noisy about non-existent import steps cssregistry and jsregist…

### DIFF
--- a/collective/js/jqueryui/profiles.zcml
+++ b/collective/js/jqueryui/profiles.zcml
@@ -44,12 +44,22 @@
   <utility factory=".setuphandlers.HiddenProducts" name="collective.js.jqueryui" />
 
   <genericsetup:importStep
+    zcml:condition="not-have plone-5"
     name="collective.js.jqueryui"
     title="collective.js.jqueryui regain priority to registry"
     description="plone.app.registry step is executed before jsregistry so fix it"
     handler=".setuphandlers.applySettings">
     <depends name="cssregistry"/>
     <depends name="jsregistry"/>
+    <depends name="plone.app.registry"/>
+  </genericsetup:importStep>
+
+  <genericsetup:importStep
+    zcml:condition="have plone-5"
+    name="collective.js.jqueryui"
+    title="collective.js.jqueryui regain priority to registry"
+    description="plone.app.registry step is executed before jsregistry so fix it"
+    handler=".setuphandlers.applySettings">
     <depends name="plone.app.registry"/>
   </genericsetup:importStep>
 


### PR DESCRIPTION
5.2 is noisy about non-existent import steps cssregistry and jsregistry. These were deprecated in 5. Use the plone-5 zcml condition to only include them as dependencies on the importStep if in Plone 5