### PR TITLE
setup requires from setuptools_git to setuptools to avoid installatio…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'Products.CMFPlone',
         'setuptools',
     ],
-    setup_requires=["setuptools_git"],
+    setup_requires=["setuptools"],
     extras_require={},
     entry_points="""
     # -*- Entry points: -*-


### PR DESCRIPTION
…n issue

Error: 

```
Develop: '/home/vagrant/Plone/zinstance/src/collective.js.jqueryui'
/home/vagrant/Plone/zinstance/src/collective.js.jqueryui/setup.py:13: DeprecationWarning: 'U' mode is deprecated
  classifiers=[
Traceback (most recent call last):
  File "/tmp/tmpci4vctlm", line 14, in <module>
    exec(compile(f.read(), '/home/vagrant/Plone/zinstance/src/collective.js.jqueryui/setup.py', 'exec'))
  File "/home/vagrant/Plone/zinstance/src/collective.js.jqueryui/setup.py", line 51, in <module>
    """,
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/setuptools/__init__.py", line 152, in setup
    _install_setup_requires(attrs)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/setuptools/__init__.py", line 147, in _install_setup_requires
    dist.fetch_build_eggs(dist.setup_requires)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/setuptools/dist.py", line 676, in fetch_build_eggs
    replace_conflicting=True,
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/pkg_resources/__init__.py", line 766, in resolve
    replace_conflicting=replace_conflicting
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1049, in best_match
    return self.obtain(req, installer)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1061, in obtain
    return installer(requirement)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/setuptools/dist.py", line 732, in fetch_build_egg
    return fetch_build_egg(self, req)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/setuptools/installer.py", line 131, in fetch_build_egg
    wheel.install_as_egg(dist_location)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/setuptools/wheel.py", line 95, in install_as_egg
    self._install_as_egg(destination_eggdir, zf)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/setuptools/wheel.py", line 103, in _install_as_egg
    self._convert_metadata(zf, destination_eggdir, dist_info, egg_info)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/setuptools/wheel.py", line 124, in _convert_metadata
    os.mkdir(destination_eggdir)
FileExistsError: [Errno 17] File exists: '/vagrant/plone/src/collective.js.jqueryui/.eggs/setuptools_git-1.2-py3.7.egg'
While:
  Installing.
  Processing develop directory '/home/vagrant/Plone/zinstance/src/collective.js.jqueryui'.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/zc/buildout/buildout.py", line 2174, in main
    getattr(buildout, command)(args)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/zc/buildout/buildout.py", line 679, in install
    installed_develop_eggs = self._develop()
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/zc/buildout/buildout.py", line 922, in _develop
    zc.buildout.easy_install.develop(setup, dest)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/zc/buildout/easy_install.py", line 1100, in develop
    call_subprocess(args)
  File "/home/vagrant/Plone/zinstance/lib/python3.7/site-packages/zc/buildout/easy_install.py", line 166, in call_subprocess
    % repr(args)[1:-1])
Exception: Failed to run command:
'/home/vagrant/Plone/zinstance/bin/python3', '/tmp/tmpci4vctlm', '-q', 'develop', '-mN', '-d', '/home/vagrant/Plone/zinstance/develop-eggs/tmp8wa7b1k3build'
```